### PR TITLE
Added remember feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "chalk": "5.6.2",
     "discord.js": "14.23.2",
+    "dotenv": "17.2.3",
     "node-fetch": "3.3.2",
     "ora": "9.0.0",
     "prompts": "2.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       discord.js:
         specifier: 14.23.2
         version: 14.23.2
+      dotenv:
+        specifier: 17.2.3
+        version: 17.2.3
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -830,6 +833,10 @@ packages:
   discord.js@14.23.2:
     resolution: {integrity: sha512-tU2NFr823X3TXEc8KyR/4m296KLxPai4nirN3q9kHCpY4TKj96n9lHZnyLzRNMui8EbL07jg9hgH2PWWfKMGIg==}
     engines: {node: '>=18'}
+
+  dotenv@17.2.3:
+    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2732,6 +2739,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  dotenv@17.2.3: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
I added a feature which allows to remember previously entered settings & the bot token, having to save the bot token somewhere and always enter it again is a pain.

<img width="823" height="322" alt="Screenshot From 2025-10-16 14-39-02" src="https://github.com/user-attachments/assets/201608e5-3c87-47a7-8b08-1d1c168d5bdb" />

Settings are saved as `settings.json` in the format `{"token":"","community":bool}`

